### PR TITLE
fix(mqtt_source): thread safety and lifecycle fixes (#25-29)

### DIFF
--- a/include/pipepp/mqtt/mqtt_source.hpp
+++ b/include/pipepp/mqtt/mqtt_source.hpp
@@ -52,7 +52,6 @@ public:
 
 private:
     void* impl_ = nullptr;
-    bool connected_ = false;
 };
 
 static_assert(pipepp::core::BusSource<mqtt_source<mqtt_default_config>, mqtt_default_config>,

--- a/src/mqtt_source.cpp
+++ b/src/mqtt_source.cpp
@@ -1,5 +1,6 @@
 #include <pipepp/mqtt/mqtt_source.hpp>
 
+#include <atomic>
 #include <cstring>
 #include <cstdlib>
 #include <thread>
@@ -39,6 +40,9 @@ struct mqtt_impl {
     mqtt_impl& operator=(const mqtt_impl&) = delete;
     mqtt_impl(mqtt_impl&&) = default;
     mqtt_impl& operator=(mqtt_impl&&) = default;
+
+    std::atomic<bool> connected{false};
+    bool callback_installed = false;
 
 #ifdef PIPEPP_MQTT_HAS_PAHO_CPP
     paho::async_client* client = nullptr;
@@ -90,40 +94,64 @@ mqtt_source<Config>::mqtt_source()
 
 template<typename Config>
 mqtt_source<Config>::~mqtt_source() {
-    if (connected_) {
-        disconnect();
-    }
     auto* p = static_cast<mqtt_impl<Config>*>(impl_);
+    if (p) {
 #ifdef PIPEPP_MQTT_HAS_PAHO_CPP
-    if (p && p->client) {
-        delete p->client;
-    }
+        if (p->client) {
+            p->client->set_connected_handler(nullptr);
+            if constexpr (std::is_same_v<typename Config::poll_mode, mqtt_callback_tag>) {
+                p->client->set_message_callback(nullptr);
+            }
+            if (p->connected.load(std::memory_order_acquire)) {
+                try {
+                    if constexpr (std::is_same_v<typename Config::poll_mode, mqtt_consumer_tag>) {
+                        p->client->stop_consuming();
+                    }
+                    p->client->disconnect(std::chrono::seconds(2))->wait_for(std::chrono::seconds(5));
+                } catch (...) {}
+            }
+            delete p->client;
+            p->client = nullptr;
+        }
 #endif
-    delete p;
+        p->connected.store(false, std::memory_order_release);
+        delete p;
+    }
     impl_ = nullptr;
 }
 
 template<typename Config>
 mqtt_source<Config>::mqtt_source(mqtt_source&& other) noexcept
-    : impl_(other.impl_)
-    , connected_(other.connected_) {
+    : impl_(other.impl_) {
     other.impl_ = nullptr;
-    other.connected_ = false;
 }
 
 template<typename Config>
 mqtt_source<Config>& mqtt_source<Config>::operator=(mqtt_source&& other) noexcept {
     if (this != &other) {
-        if (connected_) disconnect();
         auto* p = static_cast<mqtt_impl<Config>*>(impl_);
+        if (p) {
 #ifdef PIPEPP_MQTT_HAS_PAHO_CPP
-        if (p && p->client) delete p->client;
+            if (p->client) {
+                p->client->set_connected_handler(nullptr);
+                if constexpr (std::is_same_v<typename Config::poll_mode, mqtt_callback_tag>) {
+                    p->client->set_message_callback(nullptr);
+                }
+                if (p->connected.load(std::memory_order_acquire)) {
+                    try {
+                        if constexpr (std::is_same_v<typename Config::poll_mode, mqtt_consumer_tag>) {
+                            p->client->stop_consuming();
+                        }
+                        p->client->disconnect(std::chrono::seconds(2))->wait_for(std::chrono::seconds(5));
+                    } catch (...) {}
+                }
+                delete p->client;
+            }
 #endif
-        delete p;
+            delete p;
+        }
         impl_ = other.impl_;
-        connected_ = other.connected_;
         other.impl_ = nullptr;
-        other.connected_ = false;
     }
     return *this;
 }
@@ -133,6 +161,22 @@ pipepp::core::result mqtt_source<Config>::connect(pipepp::core::uri_view uri) {
 #ifdef PIPEPP_MQTT_HAS_PAHO_CPP
     auto* s = static_cast<mqtt_impl<Config>*>(impl_);
     try {
+        if (s->client) {
+            try {
+                if constexpr (std::is_same_v<typename Config::poll_mode, mqtt_consumer_tag>) {
+                    s->client->stop_consuming();
+                }
+                s->client->disconnect(std::chrono::seconds(2))->wait_for(std::chrono::seconds(5));
+            } catch (...) {}
+            s->client->set_connected_handler(nullptr);
+            if constexpr (std::is_same_v<typename Config::poll_mode, mqtt_callback_tag>) {
+                s->client->set_message_callback(nullptr);
+            }
+            delete s->client;
+            s->client = nullptr;
+        }
+        s->connected.store(false, std::memory_order_release);
+
         std::string host = uri.host.empty()
             ? std::string(static_cast<std::string_view>(s->broker_host))
             : std::string(uri.host);
@@ -184,6 +228,36 @@ pipepp::core::result mqtt_source<Config>::connect(pipepp::core::uri_view uri) {
         auto* cli = new paho::async_client(server_uri, cid);
         s->client = cli;
 
+        if (s->callback_installed) {
+            if constexpr (std::is_same_v<typename Config::poll_mode, mqtt_callback_tag>) {
+                auto* cb_ptr = &s->callback;
+                cli->set_message_callback([cb_ptr](paho::const_message_ptr msg) {
+                    if (msg && *cb_ptr) {
+                        auto topic = std::string_view(msg->get_topic());
+                        auto& payload_ref = msg->get_payload_ref();
+                        auto payload = std::span<const std::byte>(
+                            reinterpret_cast<const std::byte*>(payload_ref.data()),
+                            payload_ref.size());
+                        auto qos = msg->get_qos();
+                        pipepp::core::message_view mv(topic, payload, static_cast<uint8_t>(qos));
+                        (*cb_ptr)(mv);
+                    }
+                });
+            }
+        }
+
+        s->connected.store(false, std::memory_order_release);
+        cli->set_connected_handler([s](const std::string&) {
+            s->connected.store(true, std::memory_order_release);
+            for (std::size_t i = 0; i < s->sub_count; ++i) {
+                try {
+                    s->client->subscribe(
+                        std::string(static_cast<std::string_view>(s->subscriptions[i].topic)),
+                        s->subscriptions[i].qos);
+                } catch (...) {}
+            }
+        });
+
         auto conn_opts = paho::connect_options_builder()
             .keep_alive_interval(std::chrono::seconds(keepalive))
             .clean_session(clean_session)
@@ -234,25 +308,12 @@ pipepp::core::result mqtt_source<Config>::connect(pipepp::core::uri_view uri) {
             conn_opts.set_ssl(std::move(ssl_opts));
         }
 
-        auto* s_ptr = s;
-        auto* connected_flag = &connected_;
-        cli->set_connected_handler([s_ptr, connected_flag](const std::string&) {
-            *connected_flag = true;
-            for (std::size_t i = 0; i < s_ptr->sub_count; ++i) {
-                try {
-                    s_ptr->client->subscribe(
-                        std::string(static_cast<std::string_view>(s_ptr->subscriptions[i].topic)),
-                        s_ptr->subscriptions[i].qos);
-                } catch (...) {}
-            }
-        });
-
         if constexpr (std::is_same_v<typename Config::poll_mode, mqtt_consumer_tag>) {
             cli->start_consuming();
         }
 
         cli->connect(conn_opts)->wait_for(std::chrono::seconds(10));
-        connected_ = true;
+        s->connected.store(true, std::memory_order_release);
         return {};
     } catch (const paho::exception&) {
         return pipepp::core::result{
@@ -264,33 +325,41 @@ pipepp::core::result mqtt_source<Config>::connect(pipepp::core::uri_view uri) {
             pipepp::core::make_unexpected(pipepp::core::error_code::connection_failed)};
     }
 #else
-    connected_ = true;
+    auto* s = static_cast<mqtt_impl<Config>*>(impl_);
+    s->connected.store(true, std::memory_order_release);
     return {};
 #endif
 }
 
 template<typename Config>
 pipepp::core::result mqtt_source<Config>::disconnect() {
-#ifdef PIPEPP_MQTT_HAS_PAHO_CPP
     auto* s = static_cast<mqtt_impl<Config>*>(impl_);
-    if (s && s->client && connected_) {
+#ifdef PIPEPP_MQTT_HAS_PAHO_CPP
+    if (s && s->client && s->connected.load(std::memory_order_acquire)) {
         try {
             if constexpr (std::is_same_v<typename Config::poll_mode, mqtt_consumer_tag>) {
                 s->client->stop_consuming();
             }
             s->client->disconnect(std::chrono::seconds(5))->wait_for(std::chrono::seconds(10));
         } catch (...) {}
+        s->client->set_connected_handler(nullptr);
+        if constexpr (std::is_same_v<typename Config::poll_mode, mqtt_callback_tag>) {
+            s->client->set_message_callback(nullptr);
+        }
+        delete s->client;
+        s->client = nullptr;
     }
 #endif
-    connected_ = false;
+    if (s) s->connected.store(false, std::memory_order_release);
     return {};
 }
 
 template<typename Config>
 bool mqtt_source<Config>::is_connected() const {
-#ifdef PIPEPP_MQTT_HAS_PAHO_CPP
     auto* s = static_cast<mqtt_impl<Config>*>(impl_);
-    if (s && s->client) {
+    if (!s) return false;
+#ifdef PIPEPP_MQTT_HAS_PAHO_CPP
+    if (s->client) {
         try {
             return s->client->is_connected();
         } catch (...) {
@@ -298,7 +367,7 @@ bool mqtt_source<Config>::is_connected() const {
         }
     }
 #endif
-    return connected_;
+    return s->connected.load(std::memory_order_acquire);
 }
 
 template<typename Config>
@@ -309,12 +378,12 @@ pipepp::core::result mqtt_source<Config>::subscribe(std::string_view topic, int 
             pipepp::core::make_unexpected(pipepp::core::error_code::invalid_argument)};
     }
 #ifdef PIPEPP_MQTT_HAS_PAHO_CPP
-    if (!connected_) {
+    auto* s = static_cast<mqtt_impl<Config>*>(impl_);
+    if (!s->connected.load(std::memory_order_acquire)) {
         return pipepp::core::result{
             pipepp::core::unexpect,
             pipepp::core::make_unexpected(pipepp::core::error_code::not_connected)};
     }
-    auto* s = static_cast<mqtt_impl<Config>*>(impl_);
     try {
         s->client->subscribe(std::string(topic), qos)->wait_for(std::chrono::seconds(5));
         s->add_subscription(topic, qos);
@@ -339,12 +408,12 @@ pipepp::core::result mqtt_source<Config>::publish(std::string_view topic,
             pipepp::core::make_unexpected(pipepp::core::error_code::invalid_argument)};
     }
 #ifdef PIPEPP_MQTT_HAS_PAHO_CPP
-    if (!connected_) {
+    auto* s = static_cast<mqtt_impl<Config>*>(impl_);
+    if (!s->connected.load(std::memory_order_acquire)) {
         return pipepp::core::result{
             pipepp::core::unexpect,
             pipepp::core::make_unexpected(pipepp::core::error_code::not_connected)};
     }
-    auto* s = static_cast<mqtt_impl<Config>*>(impl_);
     try {
         auto msg = paho::make_message(
             std::string(topic),
@@ -366,6 +435,7 @@ template<typename Config>
 void mqtt_source<Config>::set_message_callback(pipepp::core::message_callback<Config> cb) {
     auto* s = static_cast<mqtt_impl<Config>*>(impl_);
     s->callback = std::move(cb);
+    s->callback_installed = true;
 #ifdef PIPEPP_MQTT_HAS_PAHO_CPP
     if (s->client) {
         auto* cb_ptr = &s->callback;


### PR DESCRIPTION
## Summary

Fixes 5 Critical severity review findings in thread safety and lifecycle management of `mqtt_source<Config>`.

### Changes
- **#25 (C1)**: Message callback now installed during `connect()` if `set_message_callback()` was called before connection
- **#26 (C2)**: `connected_` moved from `mqtt_source` to `mqtt_impl`, eliminating dangling pointer in Paho's `connected_handler` lambda
- **#27 (C3)**: Reconnect guard added — old `async_client` is disconnected and deleted before creating a new one
- **#28 (C4)**: `connected` is now `std::atomic<bool>` with proper `memory_order` semantics
- **#29 (C5)**: Destructor disables Paho callbacks (`set_connected_handler(nullptr)`, `set_message_callback(nullptr)`) before disconnecting and deleting the client

### Test Results
- 70/70 unit tests pass (stub mode, no broker required)

Closes #25, Closes #26, Closes #27, Closes #28, Closes #29