### PR TITLE
fix(mqtt_source): static_asserts for all configs, stub mode validation (#31, #32)

### DIFF
--- a/include/pipepp/mqtt/mqtt_source.hpp
+++ b/include/pipepp/mqtt/mqtt_source.hpp
@@ -55,6 +55,12 @@ private:
 };
 
 static_assert(pipepp::core::BusSource<mqtt_source<mqtt_default_config>, mqtt_default_config>,
-              "mqtt_source must satisfy BusSource concept");
+              "mqtt_source<mqtt_default_config> must satisfy BusSource concept");
+static_assert(pipepp::core::BusSource<mqtt_source<mqtt_embedded_config>, mqtt_embedded_config>,
+              "mqtt_source<mqtt_embedded_config> must satisfy BusSource concept");
+static_assert(pipepp::core::BusSource<mqtt_source<mqtt_default_consumer_config>, mqtt_default_consumer_config>,
+              "mqtt_source<mqtt_default_consumer_config> must satisfy BusSource concept");
+static_assert(pipepp::core::BusSource<mqtt_source<mqtt_embedded_consumer_config>, mqtt_embedded_consumer_config>,
+              "mqtt_source<mqtt_embedded_consumer_config> must satisfy BusSource concept");
 
 } // namespace pipepp::mqtt

--- a/src/mqtt_source.cpp
+++ b/src/mqtt_source.cpp
@@ -424,6 +424,12 @@ pipepp::core::result mqtt_source<Config>::subscribe(std::string_view topic, int 
             pipepp::core::make_unexpected(pipepp::core::error_code::connection_failed)};
     }
 #else
+    auto* s = static_cast<mqtt_impl<Config>*>(impl_);
+    if (!s || !s->connected.load(std::memory_order_acquire)) {
+        return pipepp::core::result{
+            pipepp::core::unexpect,
+            pipepp::core::make_unexpected(pipepp::core::error_code::not_connected)};
+    }
     return {};
 #endif
 }
@@ -467,6 +473,12 @@ pipepp::core::result mqtt_source<Config>::publish(std::string_view topic,
             pipepp::core::make_unexpected(pipepp::core::error_code::connection_failed)};
     }
 #else
+    auto* s = static_cast<mqtt_impl<Config>*>(impl_);
+    if (!s || !s->connected.load(std::memory_order_acquire)) {
+        return pipepp::core::result{
+            pipepp::core::unexpect,
+            pipepp::core::make_unexpected(pipepp::core::error_code::not_connected)};
+    }
     return {};
 #endif
 }

--- a/test/unit/test_mqtt_source.cpp
+++ b/test/unit/test_mqtt_source.cpp
@@ -49,15 +49,14 @@ TEST(MqttSourceTest, MoveAssignable) {
 TEST(MqttSourceTest, SubscribeWhenNotConnectedReturnsError) {
     mqtt_source<mqtt_default_config> src;
     auto r = src.subscribe("test/topic", 0);
-    // In stub mode this returns success; with Paho it returns not_connected
-    // Either way it should not crash
+    EXPECT_FALSE(r.has_value());
 }
 
 TEST(MqttSourceTest, PublishWhenNotConnectedReturnsError) {
     mqtt_source<mqtt_default_config> src;
     std::byte payload[4]{};
     auto r = src.publish("test/topic", payload, 0);
-    // In stub mode this returns success; with Paho it returns not_connected
+    EXPECT_FALSE(r.has_value());
 }
 
 TEST(MqttSourceTest, QoSValidationRejectsInvalid) {


### PR DESCRIPTION
## Summary

Fixes 2 Major severity issues in dead API and stub mode validation.

### Changes
- **#31 (Major)**: Added `static_assert` for all 4 config types (was only validating `mqtt_default_config`)
- **#32 (Major)**: Stub mode `subscribe()`/`publish()` now check connected state and return `not_connected` error, matching real Paho behavior

### Test Results
- 72/72 unit tests pass (stub mode, no broker required)

Closes #31, Closes #32