### PR TITLE
feat(#4): MQTT pipeline stages, factory functions, ADL pipe operators

### DIFF
--- a/include/pipepp/mqtt/mqtt.hpp
+++ b/include/pipepp/mqtt/mqtt.hpp
@@ -2,5 +2,7 @@
 
 #include "mqtt_config.hpp"
 #include "mqtt_error.hpp"
+#include "mqtt_pipeline.hpp"
 #include "mqtt_registry.hpp"
 #include "mqtt_source.hpp"
+#include "mqtt_stages.hpp"

--- a/include/pipepp/mqtt/mqtt_pipeline.hpp
+++ b/include/pipepp/mqtt/mqtt_pipeline.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdio>
+#include <string_view>
+
+#include <pipepp/core/pipeline.hpp>
+
+#include "mqtt_config.hpp"
+#include "mqtt_source.hpp"
+
+namespace pipepp::mqtt {
+
+struct mqtt_endpoint {
+    const char* host = "localhost";
+    int port = 1883;
+};
+
+template<typename Config = mqtt_default_config>
+pipepp::core::basic_pipeline<mqtt_source<Config>, Config>
+pipeline(const mqtt_endpoint& endpoint)
+{
+    mqtt_source<Config> src;
+    char uri[Config::max_uri_len + 1];
+    auto n = std::snprintf(uri, sizeof(uri), "mqtt://%s:%d",
+                           endpoint.host, endpoint.port);
+    auto pipe = pipepp::core::pipeline(std::move(src), Config{});
+    pipe.connect_uri(std::string_view(uri, static_cast<std::size_t>(n)));
+    return pipe;
+}
+
+template<typename Config = mqtt_default_config>
+mqtt_source<Config>
+source(const mqtt_endpoint& endpoint)
+{
+    mqtt_source<Config> src;
+    char port_buf[16];
+    std::snprintf(port_buf, sizeof(port_buf), "%d", endpoint.port);
+    src.set_broker(endpoint.host, port_buf);
+    return src;
+}
+
+} // namespace pipepp::mqtt

--- a/include/pipepp/mqtt/mqtt_stages.hpp
+++ b/include/pipepp/mqtt/mqtt_stages.hpp
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <algorithm>
+#include <cstring>
+#include <string>
+#include <string_view>
+
+#include <pipepp/core/message.hpp>
+#include <pipepp/core/pipeline.hpp>
+
+#include "mqtt_config.hpp"
+
+namespace pipepp::mqtt {
+
+inline bool mqtt_topic_matches(std::string_view filter, std::string_view topic)
+{
+    std::size_t fi = 0, ti = 0;
+    while (fi < filter.size() && ti < topic.size()) {
+        if (filter[fi] == '#') {
+            return true;
+        }
+        if (filter[fi] == '+') {
+            ++fi;
+            while (ti < topic.size() && topic[ti] != '/') {
+                ++ti;
+            }
+            if (fi < filter.size() && filter[fi] == '/') {
+                ++fi;
+            }
+            if (ti < topic.size() && topic[ti] == '/') {
+                ++ti;
+            }
+            continue;
+        }
+        if (filter[fi] != topic[ti]) {
+            return false;
+        }
+        ++fi;
+        ++ti;
+    }
+    if (fi < filter.size() && filter[fi] == '#') {
+        return true;
+    }
+    return fi == filter.size() && ti == topic.size();
+}
+
+template<typename Config = mqtt_default_config>
+struct subscribe_stage {
+    std::string topic;
+    int qos = 0;
+
+    template<typename Source>
+    pipepp::core::basic_pipeline<Source, Config>&
+    apply(pipepp::core::basic_pipeline<Source, Config>& pipe) const
+    {
+        pipe.subscribe(topic, qos);
+        auto filter_copy = topic;
+        pipe.add_stage([f = std::move(filter_copy)](pipepp::core::basic_message<Config>& msg) -> bool {
+            return mqtt_topic_matches(f, msg.topic());
+        });
+        return pipe;
+    }
+};
+
+template<typename Config = mqtt_default_config>
+struct publish_stage {
+    std::string topic_prefix;
+
+    template<typename Source>
+    pipepp::core::basic_pipeline<Source, Config>&
+    apply(pipepp::core::basic_pipeline<Source, Config>& pipe) const
+    {
+        auto* src = &pipe.source();
+        auto prefix = topic_prefix;
+        pipe.set_sink([src, p = std::move(prefix)](const pipepp::core::message_view& msg) {
+            auto full_len = p.size() + msg.topic.size();
+            if (full_len > Config::max_topic_len) {
+                full_len = Config::max_topic_len;
+            }
+            char buf[Config::max_topic_len + 1];
+            auto prefix_part = std::min(p.size(), full_len);
+            std::memcpy(buf, p.data(), prefix_part);
+            auto remaining = full_len - prefix_part;
+            std::memcpy(buf + prefix_part, msg.topic.data(), remaining);
+            src->publish(std::string_view(buf, full_len), msg.payload, msg.qos);
+        });
+        return pipe;
+    }
+};
+
+template<typename Config = mqtt_default_config>
+subscribe_stage<Config> subscribe(std::string_view topic, int qos = 0)
+{
+    return subscribe_stage<Config>{std::string(topic), qos};
+}
+
+template<typename Config = mqtt_default_config>
+publish_stage<Config> publish(std::string_view topic_prefix = {})
+{
+    return publish_stage<Config>{std::string(topic_prefix)};
+}
+
+template<typename Source, typename Config>
+pipepp::core::basic_pipeline<Source, Config>&
+operator|(pipepp::core::basic_pipeline<Source, Config>& pipe,
+          const subscribe_stage<Config>& stage)
+{
+    return stage.apply(pipe);
+}
+
+template<typename Source, typename Config>
+pipepp::core::basic_pipeline<Source, Config>&
+operator|(pipepp::core::basic_pipeline<Source, Config>& pipe,
+          const publish_stage<Config>& stage)
+{
+    return stage.apply(pipe);
+}
+
+} // namespace pipepp::mqtt


### PR DESCRIPTION
## Summary
- Add `mqtt_stages.hpp` with `subscribe_stage`, `publish_stage`, MQTT topic wildcard matching, and ADL `operator|` overloads
- Add `mqtt_pipeline.hpp` with `mqtt_endpoint`, `mqtt::pipeline()` factory, `mqtt::source()` factory
- Update umbrella header `mqtt.hpp`

Closes #4