### PR TITLE
feat(#24): Ubuntu, Alpine, Fedora, coverage Dockerfiles

### DIFF
--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -1,0 +1,27 @@
+FROM alpine:3.21
+
+RUN apk add --no-cache \
+    cmake \
+    g++ \
+    make \
+    gtest-dev \
+    openssl-dev \
+    wget \
+    && cd /tmp \
+    && wget -q https://github.com/eclipse/paho.mqtt.c/archive/refs/tags/v1.3.14.tar.gz -O paho.c.tar.gz \
+    && tar xzf paho.c.tar.gz \
+    && cd paho.mqtt.c-1.3.14 \
+    && cmake -B build -DCMAKE_BUILD_TYPE=MinSizeRel -DPAHO_ENABLE_TESTING=OFF -DPAHO_BUILD_STATIC=OFF \
+    && cmake --build build --target install \
+    && cd /tmp \
+    && wget -q https://github.com/eclipse/paho.mqtt.cpp/archive/refs/tags/v1.5.0.tar.gz -O paho.cpp.tar.gz \
+    && tar xzf paho.cpp.tar.gz \
+    && cd paho.mqtt.cpp-1.5.0 \
+    && cmake -B build -DCMAKE_BUILD_TYPE=MinSizeRel -DPAHO_BUILD_STATIC=OFF \
+    && cmake --build build --target install \
+    && ldconfig /usr/local/lib \
+    && rm -rf /tmp/paho.*
+
+WORKDIR /build
+
+CMD ["sh"]

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -5,19 +5,28 @@ RUN apk add --no-cache \
     g++ \
     make \
     gtest-dev \
+    openssl \
     openssl-dev \
     wget \
     && cd /tmp \
     && wget -q https://github.com/eclipse/paho.mqtt.c/archive/refs/tags/v1.3.14.tar.gz -O paho.c.tar.gz \
     && tar xzf paho.c.tar.gz \
     && cd paho.mqtt.c-1.3.14 \
-    && cmake -B build -DCMAKE_BUILD_TYPE=MinSizeRel -DPAHO_ENABLE_TESTING=OFF -DPAHO_BUILD_STATIC=OFF \
+    && cmake -B build \
+        -DCMAKE_BUILD_TYPE=MinSizeRel \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DPAHO_ENABLE_TESTING=OFF \
+        -DPAHO_BUILD_STATIC=OFF \
+        -DPAHO_WITH_SSL=ON \
     && cmake --build build --target install \
     && cd /tmp \
     && wget -q https://github.com/eclipse/paho.mqtt.cpp/archive/refs/tags/v1.5.0.tar.gz -O paho.cpp.tar.gz \
     && tar xzf paho.cpp.tar.gz \
     && cd paho.mqtt.cpp-1.5.0 \
-    && cmake -B build -DCMAKE_BUILD_TYPE=MinSizeRel -DPAHO_BUILD_STATIC=OFF \
+    && cmake -B build \
+        -DCMAKE_BUILD_TYPE=MinSizeRel \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DPAHO_BUILD_STATIC=OFF \
     && cmake --build build --target install \
     && ldconfig /usr/local/lib \
     && rm -rf /tmp/paho.*

--- a/docker/Dockerfile.coverage
+++ b/docker/Dockerfile.coverage
@@ -1,0 +1,16 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    cmake \
+    g++ \
+    gcovr \
+    libpaho-mqtt-dev \
+    libpaho-mqttpp-dev \
+    libgtest-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+CMD ["bash"]

--- a/docker/Dockerfile.coverage
+++ b/docker/Dockerfile.coverage
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y \
     libpaho-mqtt-dev \
     libpaho-mqttpp-dev \
     libgtest-dev \
+    libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build

--- a/docker/Dockerfile.fedora
+++ b/docker/Dockerfile.fedora
@@ -7,12 +7,13 @@ RUN dnf install -y \
     openssl-devel \
     wget \
     && cd /tmp \
-    && wget -q https://github.com/eclipse/paho.mqtt.c/archive/refs/tags/v1.3.14.tar.gz -O paho.c.tar.gz \
+    && wget -q https://github.com/eclipse/paho.mqtt.c/archive/refs/tags/v1.3.13.tar.gz -O paho.c.tar.gz \
     && tar xzf paho.c.tar.gz \
-    && cd paho.mqtt.c-1.3.14 \
+    && cd paho.mqtt.c-1.3.13 \
     && cmake -B build \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DCMAKE_C_FLAGS="-std=gnu17" \
         -DPAHO_ENABLE_TESTING=OFF \
         -DPAHO_BUILD_STATIC=OFF \
         -DPAHO_WITH_SSL=ON \

--- a/docker/Dockerfile.fedora
+++ b/docker/Dockerfile.fedora
@@ -31,6 +31,8 @@ RUN dnf install -y \
     && rm -rf /tmp/paho.* \
     && dnf clean all
 
+ENV LD_LIBRARY_PATH=/usr/local/lib64
+
 WORKDIR /build
 
 CMD ["bash"]

--- a/docker/Dockerfile.fedora
+++ b/docker/Dockerfile.fedora
@@ -1,0 +1,13 @@
+FROM fedora:42
+
+RUN dnf install -y \
+    cmake \
+    gcc-c++ \
+    paho-mqtt-devel \
+    paho-mqtt-cpp-devel \
+    gtest-devel \
+    && dnf clean all
+
+WORKDIR /build
+
+CMD ["bash"]

--- a/docker/Dockerfile.fedora
+++ b/docker/Dockerfile.fedora
@@ -3,9 +3,31 @@ FROM fedora:42
 RUN dnf install -y \
     cmake \
     gcc-c++ \
-    paho-mqtt-devel \
-    paho-mqtt-cpp-devel \
     gtest-devel \
+    openssl-devel \
+    wget \
+    && cd /tmp \
+    && wget -q https://github.com/eclipse/paho.mqtt.c/archive/refs/tags/v1.3.14.tar.gz -O paho.c.tar.gz \
+    && tar xzf paho.c.tar.gz \
+    && cd paho.mqtt.c-1.3.14 \
+    && cmake -B build \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DPAHO_ENABLE_TESTING=OFF \
+        -DPAHO_BUILD_STATIC=OFF \
+        -DPAHO_WITH_SSL=ON \
+    && cmake --build build --target install \
+    && cd /tmp \
+    && wget -q https://github.com/eclipse/paho.mqtt.cpp/archive/refs/tags/v1.5.0.tar.gz -O paho.cpp.tar.gz \
+    && tar xzf paho.cpp.tar.gz \
+    && cd paho.mqtt.cpp-1.5.0 \
+    && cmake -B build \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DPAHO_BUILD_STATIC=OFF \
+    && cmake --build build --target install \
+    && ldconfig \
+    && rm -rf /tmp/paho.* \
     && dnf clean all
 
 WORKDIR /build

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -1,0 +1,15 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    cmake \
+    g++ \
+    libpaho-mqtt-dev \
+    libpaho-mqttpp-dev \
+    libgtest-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+CMD ["bash"]

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
     libpaho-mqtt-dev \
     libpaho-mqttpp-dev \
     libgtest-dev \
+    libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build


### PR DESCRIPTION
## Summary
- `docker/Dockerfile.ubuntu` — Ubuntu 24.04 + Paho MQTT + GTest
- `docker/Dockerfile.alpine` — Alpine 3.21 + Paho MQTT from source + GTest + `-Os`
- `docker/Dockerfile.fedora` — Fedora 42 + Paho MQTT + GTest
- `docker/Dockerfile.coverage` — Ubuntu 24.04 + gcovr

Closes #24